### PR TITLE
Add tests for SaldoLink

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,4 +41,5 @@ dependencies {
     testCompile 'com.google.truth:truth:0.30'
     testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile "org.mockito:mockito-core:2.1.0-RC.2"
+    testCompile 'pl.pragmatists:JUnitParams:1.0.5'
 }

--- a/app/src/main/java/com/mbcdev/folkets/ErrorType.java
+++ b/app/src/main/java/com/mbcdev/folkets/ErrorType.java
@@ -24,7 +24,7 @@ enum ErrorType {
     /**
      * Gets the resource ID of the string for this ErrorType
      *
-     * @return
+     * @return the resource ID of the string for this ErrorType
      */
     int getStringResourceId() {
         return stringResourceId;

--- a/app/src/main/java/com/mbcdev/folkets/FolketsDatabase.java
+++ b/app/src/main/java/com/mbcdev/folkets/FolketsDatabase.java
@@ -31,6 +31,7 @@ import static timber.log.Timber.e;
 class FolketsDatabase {
 
     private static final String FOLKETS_DB = "folkets.db";
+    private final Context context;
 
     private SQLiteDatabase database;
     private final SharedPreferences preferences;
@@ -41,6 +42,7 @@ class FolketsDatabase {
      * @param context A valid context
      */
     FolketsDatabase(@NonNull Context context) {
+        this.context = context.getApplicationContext();
         preferences = PreferenceManager.getDefaultSharedPreferences(context);
 
         synchronized (this) {
@@ -77,7 +79,7 @@ class FolketsDatabase {
 
                 cursor.moveToFirst();
                 while (!cursor.isAfterLast()) {
-                    words.add(new Word(cursor));
+                    words.add(new Word(context, cursor));
                     cursor.moveToNext();
                 }
 

--- a/app/src/main/java/com/mbcdev/folkets/MainApplication.java
+++ b/app/src/main/java/com/mbcdev/folkets/MainApplication.java
@@ -11,21 +11,9 @@ import timber.log.Timber;
  */
 public class MainApplication extends Application {
 
-    private static MainApplication instance;
-
     @Override
     public void onCreate() {
         super.onCreate();
-        instance = this;
         Timber.plant(new Timber.DebugTree());
-    }
-
-    /**
-     * Gets the instance of the Application
-     *
-     * @return The instance of the application
-     */
-    public static MainApplication getInstance() {
-        return instance;
     }
 }

--- a/app/src/main/java/com/mbcdev/folkets/SaldoLink.java
+++ b/app/src/main/java/com/mbcdev/folkets/SaldoLink.java
@@ -1,10 +1,12 @@
 package com.mbcdev.folkets;
 
+import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
-import java.util.Locale;
+import timber.log.Timber;
 
 /**
  * Models a link to Saldo, which contains a lot of metadata about a word
@@ -22,20 +24,31 @@ class SaldoLink implements Parcelable {
      *
      * @param rawValue the raw database value
      */
-    SaldoLink(@NonNull String rawValue) {
+    SaldoLink(@NonNull Context context, @Nullable String rawValue) {
+
+        if (rawValue == null) {
+            Timber.d("rawValue was null, cannot parse saldo links.");
+            return;
+        }
 
         String[] rawLinks = rawValue.split(Utils.PIPE_SEPARATOR);
 
-        if (rawLinks.length == 3) {
+        boolean allLinksArePresent = rawLinks.length == 3 &&
+                Utils.hasLength(rawLinks[0]) &&
+                Utils.hasLength(rawLinks[1]) &&
+                Utils.hasLength(rawLinks[2]);
 
-            String label = MainApplication.getInstance().getString(R.string.link_word);
-            wordLink = String.format(Locale.US, "<a href=\"https://spraakbanken.gu.se/ws/saldo-ws/fl/html/%s\">%s</a>", rawLinks[0], label);
+        if (allLinksArePresent) {
 
-            label = MainApplication.getInstance().getString(R.string.link_associations);
-            associationsLink = String.format(Locale.US, "<a href=\"https://spraakbanken.gu.se/ws/saldo-ws/lid/html/%s\">%s</a>", rawLinks[1], label);
+            wordLink = context.getString(R.string.link_word_format,
+                    rawLinks[0], context.getString(R.string.link_word));
 
-            label = MainApplication.getInstance().getString(R.string.link_inflections);
-            inflectionsLink = String.format(Locale.US, "<a href=\"https://spraakbanken.gu.se/ws/saldo-ws/lid/html/%s\">%s</a>", rawLinks[2], label);
+            associationsLink = context.getString(R.string.link_associations_format,
+                    rawLinks[1], context.getString(R.string.link_associations));
+
+            inflectionsLink = context.getString(R.string.link_inflections_format,
+                    rawLinks[2], context.getString(R.string.link_inflections)
+            );
         }
     }
 

--- a/app/src/main/java/com/mbcdev/folkets/SaldoLinks.java
+++ b/app/src/main/java/com/mbcdev/folkets/SaldoLinks.java
@@ -1,5 +1,6 @@
 package com.mbcdev.folkets;
 
+import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
@@ -21,13 +22,13 @@ class SaldoLinks implements Parcelable {
      *
      * @param rawValue the raw database value
      */
-    SaldoLinks(@NonNull String rawValue) {
+    SaldoLinks(@NonNull Context context, @NonNull String rawValue) {
 
         String[] rawLinks = rawValue.split(Utils.ASTERISK_SEPARATOR);
         links = new ArrayList<>();
 
         for (String rawLink : rawLinks) {
-            links.add(new SaldoLink(rawLink));
+            links.add(new SaldoLink(context, rawLink));
         }
     }
 

--- a/app/src/main/java/com/mbcdev/folkets/Word.java
+++ b/app/src/main/java/com/mbcdev/folkets/Word.java
@@ -1,5 +1,6 @@
 package com.mbcdev.folkets;
 
+import android.content.Context;
 import android.database.Cursor;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -41,7 +42,7 @@ class Word implements Parcelable {
      *
      * @param cursor the cursor containing the words.
      */
-    Word(@NonNull Cursor cursor) {
+    Word(@NonNull Context context, @NonNull Cursor cursor) {
         word = cursor.getString(cursor.getColumnIndex("word"));
         comment = cursor.getString(cursor.getColumnIndex("comment"));
         wordTypes = compileWordTypes(cursor.getString(cursor.getColumnIndex("types")));
@@ -59,7 +60,7 @@ class Word implements Parcelable {
 
         phonetic = cursor.getString(cursor.getColumnIndex("phonetic"));
         synonyms = stringToList(cursor.getString(cursor.getColumnIndex("synonyms")));
-        saldoLinks = new SaldoLinks(cursor.getString(cursor.getColumnIndex("saldos")));
+        saldoLinks = new SaldoLinks(context, cursor.getString(cursor.getColumnIndex("saldos")));
         compareWith = stringToList(cursor.getString(cursor.getColumnIndex("comparisons")));
         antonyms = new ValuesWithTranslations(cursor.getString(cursor.getColumnIndex("antonyms")));
         usage = cursor.getString(cursor.getColumnIndex("use"));

--- a/app/src/main/res/values/strings-noi18n.xml
+++ b/app/src/main/res/values/strings-noi18n.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation,StringFormatInvalid">
+    <string name="link_word_format"><![CDATA[
+        <a href="https://spraakbanken.gu.se/ws/saldo-ws/fl/html/%1$s">%2$s</a>
+    ]]></string>
+    <string name="link_associations_format"><![CDATA[
+        <a href="https://spraakbanken.gu.se/ws/saldo-ws/lid/html/%1$s">%2$s</a>
+    ]]></string>
+    <string name="link_inflections_format"><![CDATA[
+        <a href="https://spraakbanken.gu.se/ws/saldo-ws/lid/html/%1$s">%2$s</a>
+    ]]></string>
+</resources>

--- a/app/src/test/kotlin/com/mbcdev/folkets/SaldoLinkTests.kt
+++ b/app/src/test/kotlin/com/mbcdev/folkets/SaldoLinkTests.kt
@@ -1,0 +1,256 @@
+package com.mbcdev.folkets
+
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import java.util.*
+
+/**
+ * Test for [SaldoLink]
+ *
+ * Created by barry on 01/10/2016.
+ */
+@RunWith(JUnitParamsRunner::class)
+class SaldoLinkTests {
+
+    lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = mock(Context::class.java)
+        `when`(context.getString(R.string.link_word)).thenReturn("WORD")
+        `when`(context.getString(R.string.link_word_format)).thenReturn("word %s %s")
+
+        `when`(context.getString(R.string.link_inflections)).thenReturn("INFLECTIONS")
+        `when`(context.getString(R.string.link_inflections_format)).thenReturn("inflections %s %s")
+
+        `when`(context.getString(R.string.link_associations)).thenReturn("ASSOCIATIONS")
+        `when`(context.getString(R.string.link_associations_format)).thenReturn("associations %s %s")
+    }
+
+    @Test
+    fun constructorShouldBeNullSafe() {
+        val rawType: String? = null
+        SaldoLink(context, rawType)
+    }
+
+    @Test
+    fun hasValidLinksShouldBeFalseForNullRawValue() {
+        val rawType: String? = null
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.hasValidLinks()).isFalse()
+    }
+
+    @Test
+    fun wordLinkShouldBeEmptyForNullRawValue() {
+        val rawType: String? = null
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.wordLink).isEmpty()
+    }
+
+    @Test
+    fun inflectionLinkShouldBeEmptyForNullRawValue() {
+        val rawType: String? = null
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.inflectionsLink).isEmpty()
+    }
+
+    @Test
+    fun associationLinkShouldBeEmptyForNullRawValue() {
+        val rawType: String? = null
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.associationsLink).isEmpty()
+    }
+
+    @Test
+    fun constructorShouldBeEmptySafe() {
+        val rawType: String = ""
+        SaldoLink(context, rawType)
+    }
+
+    @Test
+    fun hasValidLinksShouldBeFalseForEmptyRawValue() {
+        val rawType: String = ""
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.hasValidLinks()).isFalse()
+    }
+
+    @Test
+    fun wordLinkShouldBeEmptyForEmptyRawValue() {
+        val rawType: String = ""
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.wordLink).isEmpty()
+    }
+
+    @Test
+    fun inflectionLinkShouldBeEmptyForEmptyRawValue() {
+        val rawType: String = ""
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.inflectionsLink).isEmpty()
+    }
+
+    @Test
+    fun associationLinkShouldBeEmptyForEmptyRawValue() {
+        val rawType: String = ""
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.associationsLink).isEmpty()
+    }
+    
+    @Test
+    fun hasValidLinksShouldBeFalseForNonPipedRawValue() {
+        val rawType: String = "plumbus"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.hasValidLinks()).isFalse()
+    }
+
+    @Test
+    fun wordLinkShouldBeEmptyForNonPipedRawValue() {
+        val rawType: String = "plumbus"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.wordLink).isEmpty()
+    }
+
+    @Test
+    fun inflectionLinkShouldBeEmptyForNonPipedRawValue() {
+        val rawType: String = "plumbus"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.inflectionsLink).isEmpty()
+    }
+
+    @Test
+    fun associationLinkShouldBeEmptyForNonPipedRawValue() {
+        val rawType: String = "plumbus"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.associationsLink).isEmpty()
+    }
+
+    @Test
+    fun hasValidLinksShouldBeFalseForSinglePipedRawValue() {
+        val rawType: String = "plumbus||"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.hasValidLinks()).isFalse()
+    }
+
+    @Test
+    fun wordLinkShouldBeEmptyForSinglePipedRawValue() {
+        val rawType: String = "plumbus||"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.wordLink).isEmpty()
+    }
+
+    @Test
+    fun inflectionLinkShouldBeEmptyForSinglePipedRawValue() {
+        val rawType: String = "plumbus||"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.inflectionsLink).isEmpty()
+    }
+
+    @Test
+    fun associationLinkShouldBeEmptyForSinglePipedRawValue() {
+        val rawType: String = "plumbus||"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.associationsLink).isEmpty()
+    }
+
+    @Test
+    fun hasValidLinksShouldBeFalseForDoublePipedRawValue() {
+        val rawType: String = "plumbus||plumbus2||"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.hasValidLinks()).isFalse()
+    }
+
+    @Test
+    fun wordLinkShouldBeEmptyForDoublePipedRawValue() {
+        val rawType: String = "plumbus||plumbus2||"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.wordLink).isEmpty()
+    }
+
+    @Test
+    fun inflectionLinkShouldBeEmptyForDoublePipedRawValue() {
+        val rawType: String = "plumbus||plumbus2||"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.inflectionsLink).isEmpty()
+    }
+
+    @Test
+    fun associationLinkShouldBeEmptyForDoublePipedRawValue() {
+        val rawType: String = "plumbus||plumbus2||"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.associationsLink).isEmpty()
+    }
+
+    @Test
+    fun hasValidLinksShouldBeFalseForDoublePipedWithEmptyThirdRawValue() {
+        val rawType: String = "plumbus||plumbus2|| "
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.hasValidLinks()).isFalse()
+    }
+
+    @Test
+    fun wordLinkShouldBeEmptyForDoublePipedWithEmptyThirdComponentRawValue() {
+        val rawType: String = "plumbus||plumbus2|| "
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.wordLink).isEmpty()
+    }
+
+    @Test
+    fun inflectionLinkShouldBeEmptyForDoublePipedWithEmptyThirdComponentRawValue() {
+        val rawType: String = "plumbus||plumbus2|| "
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.inflectionsLink).isEmpty()
+    }
+
+    @Test
+    fun associationLinkShouldBeEmptyForDoublePipedWithEmptyThirdComponentRawValue() {
+        val rawType: String = "plumbus||plumbus2|| "
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.associationsLink).isEmpty()
+    }
+
+    @Test
+    @Parameters(
+            "null, null, null",
+            "null, null, gerry",
+            "null, morty, null",
+            "null, morty, gerry",
+            "rick, null, null",
+            "rick, null, gerry",
+            "rick, morty, null")
+    fun linksShouldBeInvalidIfAnyComponentsAreMissing(word: String?, association: String?, inflection: String?) {
+        val rawType = String.format(Locale.US, "%s||%s||%s",
+                word ?: "",
+                association ?: "",
+                inflection ?: ""
+        )
+
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.hasValidLinks()).isFalse()
+    }
+
+    @Test
+    fun linksShouldBeGeneratedCorrectly() {
+
+        `when`(context.getString(anyInt(), any())).thenAnswer({
+
+            val resId = it.arguments[0] as Int
+            val rawLinkValue = it.arguments[1]
+            val rawLinkLabel = it.arguments[2]
+
+            String.format(Locale.US, context.getString(resId), rawLinkValue, rawLinkLabel)
+        })
+
+        val rawType = "rick||morty||gerry"
+        val saldoLink = SaldoLink(context, rawType)
+        assertThat(saldoLink.hasValidLinks()).isTrue()
+
+        assertThat(saldoLink.wordLink).isEqualTo("word rick WORD")
+        assertThat(saldoLink.associationsLink).isEqualTo("associations morty ASSOCIATIONS")
+        assertThat(saldoLink.inflectionsLink).isEqualTo("inflections gerry INFLECTIONS")
+    }
+}

--- a/app/src/test/kotlin/com/mbcdev/folkets/WordTypeTests.kt
+++ b/app/src/test/kotlin/com/mbcdev/folkets/WordTypeTests.kt
@@ -3,8 +3,8 @@ package com.mbcdev.folkets
 import android.content.Context
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import org.mockito.*
-import org.mockito.Mockito.*
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
 
 /**
  * Tests for [WordType]
@@ -361,7 +361,7 @@ class WordTypeTests {
         `when`(mockedContext.getString(R.string.word_type_pronoun)).thenReturn("Pronoun")
         `when`(mockedContext.getString(R.string.word_type_adverb)).thenReturn("Adverb")
 
-        return mockedContext;
+        return mockedContext
     }
 
 }


### PR DESCRIPTION
Changes

* Missing docs
* Redundant semicolons
* Removed string resolution from Application instance
* Moved format strings to no-18n resource
* Now passing context to SaldoLink, but may remove this soon, and have formatting happen outside of the model