### PR TITLE
Adds more tests for text to speech operations

### DIFF
--- a/app/src/main/java/com/mbcdev/folkets/FolketsTextToSpeech.java
+++ b/app/src/main/java/com/mbcdev/folkets/FolketsTextToSpeech.java
@@ -10,6 +10,7 @@ import com.zendesk.util.StringUtils;
 
 import java.util.Locale;
 
+import io.fabric.sdk.android.Fabric;
 import timber.log.Timber;
 
 /**
@@ -73,11 +74,14 @@ class FolketsTextToSpeech {
 
         textToSpeech.speak(phrase, TextToSpeech.QUEUE_FLUSH, null);
 
-        CustomEvent event = new CustomEvent("TTS")
-                .putCustomAttribute("Language", language.getCode())
-                .putCustomAttribute("Phrase", phrase);
+        if (Fabric.isInitialized()) {
+            CustomEvent event = new CustomEvent("TTS")
+                    .putCustomAttribute("Language", language.getCode())
+                    .putCustomAttribute("Phrase", phrase);
 
-        Answers.getInstance().logCustom(event);
+            Answers.getInstance().logCustom(event);
+        }
+
         return FolketsSpeechStatus.SUCCESS;
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -45,7 +45,5 @@
     <string name="link_associations">VERBÄNDE</string>
     <string name="link_inflections">FLEXIONEN</string>
     <string name="action_help">Hilfe</string>
-
-    <!-- check with Mr. Seb -->
-    <string name="tts_volume_too_low">Die Lautstärke ist zu niedrig, um das Wort zu hören!</string>
+    <string name="tts_volume_too_low">Die Lautstärke ist zu leise, um das Wort verstehen zu können!</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -45,5 +45,7 @@
     <string name="link_associations">VERBÄNDE</string>
     <string name="link_inflections">FLEXIONEN</string>
     <string name="action_help">Hilfe</string>
+
+    <!-- check with Mr. Seb -->
     <string name="tts_volume_too_low">Die Lautstärke ist zu niedrig, um das Wort zu hören!</string>
 </resources>

--- a/app/src/test/kotlin/com/mbcdev/folkets/FolketsTextToSpeechTests.kt
+++ b/app/src/test/kotlin/com/mbcdev/folkets/FolketsTextToSpeechTests.kt
@@ -2,9 +2,12 @@ package com.mbcdev.folkets
 
 import android.speech.tts.TextToSpeech
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.verifyZeroInteractions
-import org.mockito.Mockito.mock
+import org.mockito.*
+import org.mockito.Mockito.*
+import java.util.*
+import kotlin.collections.HashMap
 
 /**
  * Tests for [FolketsTextToSpeech]
@@ -12,6 +15,17 @@ import org.mockito.Mockito.mock
  * Created by barry on 09/07/2017.
  */
 class FolketsTextToSpeechTests {
+
+    @Captor
+    lateinit var paramsCaptor : ArgumentCaptor<HashMap<String, String>>
+
+    @Mock
+    lateinit var mockedTts : TextToSpeech
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.initMocks(this)
+    }
 
     @Test
     fun `speech does not work if the underlying TTS is null`() {
@@ -25,7 +39,6 @@ class FolketsTextToSpeechTests {
 
     @Test
     fun `speech does not work if the underying TTS has no onInit listener`() {
-        val mockedTts = mock(TextToSpeech::class.java)
         val folketsTts = FolketsTextToSpeech(mockedTts, null)
 
         val ttsStatus = folketsTts.speak(null, null)
@@ -37,7 +50,6 @@ class FolketsTextToSpeechTests {
 
     @Test
     fun `speech does not work if the onInit listener is not ready`() {
-        val mockedTts = mock(TextToSpeech::class.java)
         val realListener = FolketsTextToSpeechInitListener()
         val folketsTts = FolketsTextToSpeech(mockedTts, realListener)
 
@@ -50,7 +62,6 @@ class FolketsTextToSpeechTests {
 
     @Test
     fun `speech does not work if the language and phrase are missing`() {
-        val mockedTts = mock(TextToSpeech::class.java)
         val realListener = FolketsTextToSpeechInitListener()
         realListener.onInit(TextToSpeech.SUCCESS)
         val folketsTts = FolketsTextToSpeech(mockedTts, realListener)
@@ -64,7 +75,6 @@ class FolketsTextToSpeechTests {
 
     @Test
     fun `speech does not work if the language is missing`() {
-        val mockedTts = mock(TextToSpeech::class.java)
         val realListener = FolketsTextToSpeechInitListener()
         realListener.onInit(TextToSpeech.SUCCESS)
         val folketsTts = FolketsTextToSpeech(mockedTts, realListener)
@@ -78,7 +88,6 @@ class FolketsTextToSpeechTests {
 
     @Test
     fun `speech does not work if the phrase is missing`() {
-        val mockedTts = mock(TextToSpeech::class.java)
         val realListener = FolketsTextToSpeechInitListener()
         realListener.onInit(TextToSpeech.SUCCESS)
         val folketsTts = FolketsTextToSpeech(mockedTts, realListener)
@@ -88,5 +97,90 @@ class FolketsTextToSpeechTests {
         assertThat(ttsStatus).isNotNull()
         assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.ERROR_LANGUAGE_OR_PHRASE_MISSING)
         verifyZeroInteractions(mockedTts)
+    }
+
+    @Test
+    fun `speech takes language from input when its current language is null`() {
+        `when`(mockedTts.language).thenReturn(null)
+
+        val realListener = FolketsTextToSpeechInitListener()
+        realListener.onInit(TextToSpeech.SUCCESS)
+        val folketsTts = FolketsTextToSpeech(mockedTts, realListener)
+
+        val ttsStatus = folketsTts.speak(Language.ENGLISH, "Ireland")
+
+        assertThat(ttsStatus).isNotNull()
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.SUCCESS)
+
+        val localeCaptor = ArgumentCaptor.forClass(Locale::class.java)
+        verify(mockedTts, atMost(1)).language = localeCaptor.capture()
+
+        val locale = localeCaptor.value
+        assertThat(locale).isEqualTo(Language.ENGLISH.locale)
+    }
+
+    @Test
+    fun `speech uses previous language when it matches the requested language`() {
+        `when`(mockedTts.language).thenReturn(Language.SWEDISH.locale)
+
+        val realListener = FolketsTextToSpeechInitListener()
+        realListener.onInit(TextToSpeech.SUCCESS)
+        val folketsTts = FolketsTextToSpeech(mockedTts, realListener)
+
+        val ttsStatus = folketsTts.speak(Language.SWEDISH, "Sverige")
+
+        assertThat(ttsStatus).isNotNull()
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.SUCCESS)
+
+        verify(mockedTts, atMost(0)).language = ArgumentMatchers.any()
+    }
+
+    @Test
+    fun `speech switches language when it does not match the requested language`() {
+        `when`(mockedTts.language).thenReturn(Language.SWEDISH.locale)
+
+        val realListener = FolketsTextToSpeechInitListener()
+        realListener.onInit(TextToSpeech.SUCCESS)
+        val folketsTts = FolketsTextToSpeech(mockedTts, realListener)
+
+        val ttsStatus = folketsTts.speak(Language.ENGLISH, "Dublin")
+
+        assertThat(ttsStatus).isNotNull()
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.SUCCESS)
+
+        val localeCaptor = ArgumentCaptor.forClass(Locale::class.java)
+        verify(mockedTts, atMost(1)).language = localeCaptor.capture()
+
+        val locale = localeCaptor.value
+        assertThat(locale).isEqualTo(Language.ENGLISH.locale)
+    }
+
+    @Test
+    fun `speak is called with the correct arguments`() {
+        `when`(mockedTts.language).thenReturn(Language.SWEDISH.locale)
+
+        val realListener = FolketsTextToSpeechInitListener()
+        realListener.onInit(TextToSpeech.SUCCESS)
+        val folketsTts = FolketsTextToSpeech(mockedTts, realListener)
+
+        val ttsStatus = folketsTts.speak(Language.SWEDISH, "Göteborg")
+
+        assertThat(ttsStatus).isNotNull()
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.SUCCESS)
+
+        val phraseCaptor = ArgumentCaptor.forClass(String::class.java)
+        val queueModeCaptor = ArgumentCaptor.forClass(Int::class.java)
+
+        verify(mockedTts, atMost(1)).speak(
+                phraseCaptor.capture(), queueModeCaptor.capture(), paramsCaptor.capture())
+
+        val phrase = phraseCaptor.value
+        assertThat(phrase).isEqualTo("Göteborg")
+
+        val queueMode = queueModeCaptor.value
+        assertThat(queueMode).isEqualTo(TextToSpeech.QUEUE_FLUSH)
+
+        val params = paramsCaptor.value
+        assertThat(params).isNull()
     }
 }


### PR DESCRIPTION
Tests were added to cover language switching, and to ensure that the correct parameters are passed to the speak method.

The Answers reporting was wrapped in a Fabric.isInitialized() because it's not initialised during unit testing, and was causing an Exception.

@schlan is the `tts_volume_too_low` key good? It was mostly Google Translate!