### PR TITLE
Handle cases where TTS is not available

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
 
         minSdkVersion 19
         targetSdkVersion 26
-        versionCode 11
-        versionName "1.1"
+        versionCode 12
+        versionName "1.2"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -40,6 +40,10 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+        }
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Folkets Debug</string>
+</resources>

--- a/app/src/main/assets/help_center_article_style.css
+++ b/app/src/main/assets/help_center_article_style.css
@@ -1,0 +1,69 @@
+/*=========================================
+Resets the styling of all HTML elements to a consistent baseline.
+=========================================== */
+html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,em,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,table,caption,tbody,tfoot,thead,tr,th,td,article,aside,canvas,details,embed,figure,figcaption,footer,header,hgroup,menu,nav,output,ruby,section,summary,time,mark,audio,video{border:0;font-size:100%;font:inherit;vertical-align:baseline;margin:0;padding:0}article,aside,details,figcaption,figure,footer,header,hgroup,menu,nav,section{display:block}body{line-height:1}blockquote,q{quotes:none}blockquote:before,blockquote:after,q:before,q:after{content:none}table{border-collapse:collapse;border-spacing:0}
+*, *:before, *:after { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; }
+.group:before,
+.group:after { content: ""; display: table;}
+.group:after { clear: both;}
+.group { zoom: 1;}
+.hidden { display: none; }
+
+/*=========================================
+Default styling for help center articles. Alter this file to customize the styling.
+=========================================== */
+
+body {
+    font: 1em/1.5em "Helvetica Neue", Helvetica, Arial, sans-serif;
+    color:#666;
+    -webkit-font-smoothing:antialiased;
+    text-rendering:optimizeLegibility;
+    margin: 30px;
+    background-color: #ffffff;
+}
+
+a {
+    color: #4ba7f2;
+    text-decoration: none;
+}
+
+a:link {-webkit-tap-highlight-color: #c5c5c5;}
+
+strong{
+    font-weight:bold;
+}
+
+h1, h2, h3, h4, h5, h6{
+    color:#333;
+    font-weight:bold;
+    margin-bottom: 20px;
+    line-height: 1.25em;
+}
+
+h1 {font-size:1.728em;}
+h2 {font-size:1.44em;}
+h3 {font-size:1.2em;}
+h4 {font-size:1em;}
+h5 {font-size:.833em;}
+h6 {font-size:.833em;}
+
+
+span{
+    font-size: 1em !important;
+}
+
+p, ul, ol{
+    margin-bottom: 40px;
+}
+
+li{
+    margin-bottom: 10px;
+}
+
+ul ul, ol ol{
+    margin-left: 20px;
+}
+
+footer {
+    display: none;
+}

--- a/app/src/main/java/com/mbcdev/folkets/MainActivity.java
+++ b/app/src/main/java/com/mbcdev/folkets/MainActivity.java
@@ -2,7 +2,9 @@ package com.mbcdev.folkets;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.ActionBar;
@@ -13,14 +15,19 @@ import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.SearchView;
 
 import com.crashlytics.android.answers.Answers;
+import com.zendesk.sdk.model.helpcenter.SimpleArticle;
 import com.zendesk.sdk.support.SupportActivity;
+import com.zendesk.sdk.support.ViewArticleActivity;
 
 import java.util.List;
+
+import timber.log.Timber;
 
 /**
  * This activity will show a list of words and translations, and allow users to tap on a result
@@ -34,6 +41,7 @@ public class MainActivity extends AppCompatActivity implements MainMvp.View {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         setContentView(R.layout.activity_main);
 
         Toolbar toolbar = findViewById(R.id.toolbar);
@@ -64,6 +72,7 @@ public class MainActivity extends AppCompatActivity implements MainMvp.View {
     protected void onDestroy() {
         super.onDestroy();
         presenter.detach();
+        Timber.d("onDestroy");
     }
 
     @Override
@@ -139,7 +148,49 @@ public class MainActivity extends AppCompatActivity implements MainMvp.View {
 
     @Override
     public void speak(Word word) {
-        MainApplication.instance().speak(word);
+        FolketsTextToSpeech.SpeechStatus status = MainApplication.instance().speak(word);
+        presenter.onTtsResult(status);
+    }
+
+    @Override
+    public void showLowVolumeError() {
+
+        Snackbar.make(recyclerView, R.string.tts_volume_too_low, Snackbar.LENGTH_LONG)
+                .setAction(R.string.error_audio_settings, new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        Intent intent = new Intent(Settings.ACTION_SOUND_SETTINGS);
+                        startActivity(intent);
+                    }
+                })
+                .show();
+    }
+
+    @Override
+    public void showLanguageNotSupportedError() {
+        Snackbar.make(recyclerView, R.string.error_tts_didnt_work, Snackbar.LENGTH_INDEFINITE)
+                .setAction(R.string.error_fix_it, new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        Intent viewArticleIntent = new Intent(MainActivity.this, ViewArticleActivity.class);
+                        viewArticleIntent.putExtra("article_simple", new SimpleArticle(115004243105L, ""));
+                        viewArticleIntent.putExtra("extra_contact_us_button_visibility", false);
+
+                        Intent ttsSettingsIntent = new Intent();
+                        ttsSettingsIntent.setAction("com.android.settings.TTS_SETTINGS");
+
+                        startActivities(new Intent[] {
+                                ttsSettingsIntent,
+                                viewArticleIntent
+                        });
+                    }
+                })
+                .show();
+    }
+
+    @Override
+    public void showGenericTTsError(FolketsTextToSpeech.SpeechStatus status) {
+        Snackbar.make(recyclerView, R.string.error_tts_didnt_work, Snackbar.LENGTH_LONG).show();
     }
 
     /**

--- a/app/src/main/java/com/mbcdev/folkets/MainApplication.java
+++ b/app/src/main/java/com/mbcdev/folkets/MainApplication.java
@@ -3,7 +3,6 @@ package com.mbcdev.folkets;
 import android.app.Application;
 import android.media.AudioManager;
 import android.speech.tts.TextToSpeech;
-import android.widget.Toast;
 
 import com.crashlytics.android.Crashlytics;
 import com.zendesk.logger.Logger;
@@ -39,6 +38,7 @@ public class MainApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+
         Fabric.with(this, new Crashlytics());
         instance = this;
 
@@ -78,17 +78,22 @@ public class MainApplication extends Application {
      *
      * @param word The word to speak with TTS
      */
-    public void speak(Word word) {
+    public FolketsTextToSpeech.SpeechStatus speak(Word word) {
 
         if (audioManager != null && audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
-            Toast.makeText(this, R.string.tts_volume_too_low, Toast.LENGTH_SHORT).show();
+            return FolketsTextToSpeech.SpeechStatus.ERROR_VOLUME_TOO_LOW;
         }
 
+        FolketsTextToSpeech.SpeechStatus status =
+                FolketsTextToSpeech.SpeechStatus.ERROR_TTS_NULL;
+
         if (textToSpeech != null) {
-            textToSpeech.speak(
+            status = textToSpeech.speak(
                     Language.fromLanguageCode(word.getSourceLanguage()),
                     word.getWord()
             );
         }
+
+        return status;
     }
 }

--- a/app/src/main/java/com/mbcdev/folkets/MainMvp.java
+++ b/app/src/main/java/com/mbcdev/folkets/MainMvp.java
@@ -68,6 +68,35 @@ interface MainMvp {
          * @param word the word to speak
          */
         void speak(Word word);
+
+        /**
+         * Shows a snackbar when the current language is not supported. This could be because
+         * the language is not supported by the TTS engine, or it is supported, but some required
+         * TTS data is missing.
+         */
+        void showLanguageNotSupportedError();
+
+        /**
+         * Shows a snackbar when the volume is too low to hear the tts
+         */
+        void showLowVolumeError();
+
+        /**
+         * Shows a generic error for tts.
+         * <p>
+         *     The error will be one of these types:
+         *
+         *     <ul>
+         *         <li>{@link FolketsTextToSpeech.SpeechStatus#ERROR_TTS_NULL}</li>
+         *         <li>{@link FolketsTextToSpeech.SpeechStatus#ERROR_LISTENER_NULL}</li>
+         *         <li>{@link FolketsTextToSpeech.SpeechStatus#ERROR_TTS_NOT_READY}</li>
+         *         <li>{@link FolketsTextToSpeech.SpeechStatus#ERROR_LANGUAGE_OR_PHRASE_MISSING}</li>
+         *     </ul>
+         * </p>
+         *
+         * @param status The status of the error
+         */
+        void showGenericTTsError(FolketsTextToSpeech.SpeechStatus status);
     }
 
     /**
@@ -112,5 +141,12 @@ interface MainMvp {
          * @param word The word that was selected
          */
         void onTtsRequested(Word word);
+
+        /**
+         * Called when text to speech has completed
+         *
+         * @param status the status of the text to speech
+         */
+        void onTtsResult(FolketsTextToSpeech.SpeechStatus status);
     }
 }

--- a/app/src/main/java/com/mbcdev/folkets/MainPresenter.java
+++ b/app/src/main/java/com/mbcdev/folkets/MainPresenter.java
@@ -107,6 +107,31 @@ class MainPresenter implements MainMvp.Presenter {
         }
     }
 
+    @Override
+    public void onTtsResult(FolketsTextToSpeech.SpeechStatus status) {
+        if (view != null && status != null) {
+
+            switch (status) {
+
+                case ERROR_TTS_NULL:
+                case ERROR_LISTENER_NULL:
+                case ERROR_TTS_NOT_READY:
+                case ERROR_LANGUAGE_OR_PHRASE_MISSING:
+                    view.showGenericTTsError(status);
+                    break;
+                case ERROR_LANGUAGE_NOT_SUPPORTED:
+                    view.showLanguageNotSupportedError();
+                    break;
+                case ERROR_VOLUME_TOO_LOW:
+                    view.showLowVolumeError();
+                    break;
+                case SUCCESS:
+                    break;
+            }
+
+        }
+    }
+
     @VisibleForTesting
     static class SearchCallback implements Callback<List<Word>> {
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -45,5 +45,8 @@
     <string name="link_associations">VERBÄNDE</string>
     <string name="link_inflections">FLEXIONEN</string>
     <string name="action_help">Hilfe</string>
-    <string name="tts_volume_too_low">Die Lautstärke ist zu leise, um das Wort verstehen zu können!</string>
+    <string name="tts_volume_too_low">Ups, die Lautstärke ist zu leise!</string>
+    <string name="error_audio_settings">Audio Einstellungen</string>
+    <string name="error_fix_it">Repariere es</string>
+    <string name="error_tts_didnt_work">Ups!, die Sprache hat nicht funktioniert!</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -50,6 +50,9 @@
 
     <string name="error_database_null">Hoppsan! Det verkar som att något är fel i databasen.</string>
     <string name="action_help">Hjälp</string>
-    <string name="tts_volume_too_low">Volymen är för låg för att höras ordet!</string>
+    <string name="tts_volume_too_low">Hoppsan! Volymen är för låg!</string>
+    <string name="error_audio_settings">Ljudinställningar</string>
+    <string name="error_fix_it">Fixa det</string>
+    <string name="error_tts_didnt_work">Hoppsan! Talet fungerade inte!</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,5 +50,8 @@
     <string name="error_database_null">Oops!, seems like the database is missing.</string>
     <string name="action_help">Help</string>
 
-    <string name="tts_volume_too_low">The volume is too low to hear the word!</string>
+    <string name="tts_volume_too_low">Oops!, The  volume is too low!</string>
+    <string name="error_fix_it">Fix it</string>
+    <string name="error_tts_didnt_work">Oops!, the speech didn\'t work!</string>
+    <string name="error_audio_settings">Audio Settings</string>
 </resources>

--- a/app/src/test/kotlin/com/mbcdev/folkets/FolketsTextToSpeechTests.kt
+++ b/app/src/test/kotlin/com/mbcdev/folkets/FolketsTextToSpeechTests.kt
@@ -7,7 +7,6 @@ import org.junit.Test
 import org.mockito.*
 import org.mockito.Mockito.*
 import java.util.*
-import kotlin.collections.HashMap
 
 /**
  * Tests for [FolketsTextToSpeech]
@@ -34,7 +33,7 @@ class FolketsTextToSpeechTests {
         val ttsStatus = folketsTts.speak(null, null)
 
         assertThat(ttsStatus).isNotNull()
-        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.ERROR_TTS_NULL)
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_TTS_NULL)
     }
 
     @Test
@@ -44,7 +43,7 @@ class FolketsTextToSpeechTests {
         val ttsStatus = folketsTts.speak(null, null)
 
         assertThat(ttsStatus).isNotNull()
-        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.ERROR_LISTENER_NULL)
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_LISTENER_NULL)
         verifyZeroInteractions(mockedTts)
     }
 
@@ -56,7 +55,7 @@ class FolketsTextToSpeechTests {
         val ttsStatus = folketsTts.speak(null, null)
 
         assertThat(ttsStatus).isNotNull()
-        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.ERROR_TTS_NOT_READY)
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_TTS_NOT_READY)
         verifyZeroInteractions(mockedTts)
     }
 
@@ -69,7 +68,7 @@ class FolketsTextToSpeechTests {
         val ttsStatus = folketsTts.speak(null, null)
 
         assertThat(ttsStatus).isNotNull()
-        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.ERROR_LANGUAGE_OR_PHRASE_MISSING)
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_LANGUAGE_OR_PHRASE_MISSING)
         verifyZeroInteractions(mockedTts)
     }
 
@@ -82,7 +81,7 @@ class FolketsTextToSpeechTests {
         val ttsStatus = folketsTts.speak(null, "foto")
 
         assertThat(ttsStatus).isNotNull()
-        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.ERROR_LANGUAGE_OR_PHRASE_MISSING)
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_LANGUAGE_OR_PHRASE_MISSING)
         verifyZeroInteractions(mockedTts)
     }
 
@@ -95,8 +94,36 @@ class FolketsTextToSpeechTests {
         val ttsStatus = folketsTts.speak(Language.ENGLISH, "")
 
         assertThat(ttsStatus).isNotNull()
-        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.ERROR_LANGUAGE_OR_PHRASE_MISSING)
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_LANGUAGE_OR_PHRASE_MISSING)
         verifyZeroInteractions(mockedTts)
+    }
+
+    @Test
+    fun `speech does not work if the language is missing data`() {
+        val realListener = FolketsTextToSpeechInitListener()
+        realListener.onInit(TextToSpeech.SUCCESS)
+
+        `when`(mockedTts.isLanguageAvailable(ArgumentMatchers.any())).thenReturn(TextToSpeech.LANG_MISSING_DATA)
+
+        val folketsTts = FolketsTextToSpeech(mockedTts, realListener)
+        val ttsStatus = folketsTts.speak(Language.ENGLISH, "train")
+
+        assertThat(ttsStatus).isNotNull()
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_LANGUAGE_NOT_SUPPORTED)
+    }
+
+    @Test
+    fun `speech does not work if the language is not supported`() {
+        val realListener = FolketsTextToSpeechInitListener()
+        realListener.onInit(TextToSpeech.SUCCESS)
+
+        `when`(mockedTts.isLanguageAvailable(ArgumentMatchers.any())).thenReturn(TextToSpeech.LANG_NOT_SUPPORTED)
+
+        val folketsTts = FolketsTextToSpeech(mockedTts, realListener)
+        val ttsStatus = folketsTts.speak(Language.SWEDISH, "tåg")
+
+        assertThat(ttsStatus).isNotNull()
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_LANGUAGE_NOT_SUPPORTED)
     }
 
     @Test
@@ -110,7 +137,7 @@ class FolketsTextToSpeechTests {
         val ttsStatus = folketsTts.speak(Language.ENGLISH, "Ireland")
 
         assertThat(ttsStatus).isNotNull()
-        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.SUCCESS)
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.SUCCESS)
 
         val localeCaptor = ArgumentCaptor.forClass(Locale::class.java)
         verify(mockedTts, atMost(1)).language = localeCaptor.capture()
@@ -130,7 +157,7 @@ class FolketsTextToSpeechTests {
         val ttsStatus = folketsTts.speak(Language.SWEDISH, "Sverige")
 
         assertThat(ttsStatus).isNotNull()
-        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.SUCCESS)
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.SUCCESS)
 
         verify(mockedTts, atMost(0)).language = ArgumentMatchers.any()
     }
@@ -146,7 +173,7 @@ class FolketsTextToSpeechTests {
         val ttsStatus = folketsTts.speak(Language.ENGLISH, "Dublin")
 
         assertThat(ttsStatus).isNotNull()
-        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.SUCCESS)
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.SUCCESS)
 
         val localeCaptor = ArgumentCaptor.forClass(Locale::class.java)
         verify(mockedTts, atMost(1)).language = localeCaptor.capture()
@@ -166,7 +193,7 @@ class FolketsTextToSpeechTests {
         val ttsStatus = folketsTts.speak(Language.SWEDISH, "Göteborg")
 
         assertThat(ttsStatus).isNotNull()
-        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.FolketsSpeechStatus.SUCCESS)
+        assertThat(ttsStatus).isEqualTo(FolketsTextToSpeech.SpeechStatus.SUCCESS)
 
         val phraseCaptor = ArgumentCaptor.forClass(String::class.java)
         val queueModeCaptor = ArgumentCaptor.forClass(Int::class.java)

--- a/app/src/test/kotlin/com/mbcdev/folkets/MainPresenterUnitTests.kt
+++ b/app/src/test/kotlin/com/mbcdev/folkets/MainPresenterUnitTests.kt
@@ -6,10 +6,9 @@ import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers
 import org.mockito.Mock
-import org.mockito.Mockito
-import org.mockito.Mockito.*
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyZeroInteractions
 import org.mockito.MockitoAnnotations.initMocks
-import java.util.ArrayList
 
 
 /**
@@ -86,4 +85,54 @@ class MainPresenterUnitTests {
 
         assertThat(word.word).isEqualTo("Hjo")
     }
+
+    @Test
+    fun `onTtsResult calls view is null safe`() {
+        presenter.onTtsResult(null)
+    }
+
+    @Test
+    fun `onTtsResult calls view on low volume error`() {
+        presenter.onTtsResult(FolketsTextToSpeech.SpeechStatus.ERROR_VOLUME_TOO_LOW)
+        verify(view).showLowVolumeError()
+    }
+
+    @Test
+    fun `onTtsResult calls view language not supported error`() {
+        presenter.onTtsResult(FolketsTextToSpeech.SpeechStatus.ERROR_LANGUAGE_NOT_SUPPORTED)
+        verify(view).showLanguageNotSupportedError()
+    }
+
+    @Test
+    fun `onTtsResult calls generic tts error when status is ERROR_TTS_NULL`() {
+        presenter.onTtsResult(FolketsTextToSpeech.SpeechStatus.ERROR_TTS_NULL)
+        val statusCaptor = ArgumentCaptor.forClass(FolketsTextToSpeech.SpeechStatus::class.java)
+        verify(view).showGenericTTsError(statusCaptor.capture())
+        assertThat(statusCaptor.value).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_TTS_NULL)
+    }
+
+    @Test
+    fun `onTtsResult calls generic tts error when status is ERROR_LISTENER_NULL`() {
+        presenter.onTtsResult(FolketsTextToSpeech.SpeechStatus.ERROR_LISTENER_NULL)
+        val statusCaptor = ArgumentCaptor.forClass(FolketsTextToSpeech.SpeechStatus::class.java)
+        verify(view).showGenericTTsError(statusCaptor.capture())
+        assertThat(statusCaptor.value).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_LISTENER_NULL)
+    }
+
+    @Test
+    fun `onTtsResult calls generic tts error when status is ERROR_TTS_NOT_READY`() {
+        presenter.onTtsResult(FolketsTextToSpeech.SpeechStatus.ERROR_TTS_NOT_READY)
+        val statusCaptor = ArgumentCaptor.forClass(FolketsTextToSpeech.SpeechStatus::class.java)
+        verify(view).showGenericTTsError(statusCaptor.capture())
+        assertThat(statusCaptor.value).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_TTS_NOT_READY)
+    }
+
+    @Test
+    fun `onTtsResult calls generic tts error when status is ERROR_LANGUAGE_OR_PHRASE_MISSING`() {
+        presenter.onTtsResult(FolketsTextToSpeech.SpeechStatus.ERROR_LANGUAGE_OR_PHRASE_MISSING)
+        val statusCaptor = ArgumentCaptor.forClass(FolketsTextToSpeech.SpeechStatus::class.java)
+        verify(view).showGenericTTsError(statusCaptor.capture())
+        assertThat(statusCaptor.value).isEqualTo(FolketsTextToSpeech.SpeechStatus.ERROR_LANGUAGE_OR_PHRASE_MISSING)
+    }
+
 }


### PR DESCRIPTION
* Add new error states for TTS when language is not supported, or when TTS data is missing.
* Hide footer in Help Center articles.
* Handle the audio error in a snackbar, and not a toast.