### PR TITLE
Update travis configuration to use trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
-dist: precise
+dist: trusty
+group: edge
 jdk:
 - oraclejdk8
 language: android
@@ -9,7 +10,6 @@ android:
   - platform-tools
   - android-26
   - build-tools-26.0.0
-  - extra-android-m2repository
 before_script: ./app/scripts/travis_before_script.sh
 script: ./app/scripts/travis_script.sh
 after_failure:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix ".debug"
+            ext.enableCrashlytics = false
         }
 
         release {
@@ -58,6 +59,16 @@ android {
     sourceSets {
         test.java.srcDirs += 'src/test/kotlin'
         androidTest.java.srcDirs += 'src/androidTest/kotlin'
+    }
+
+    dexOptions {
+        if ('true' == System.getenv('CI')) {
+            println "Disabling preDexLibraries on CI environment"
+            preDexLibraries = false
+        } else {
+            println "Enabling preDexLibraries on non CI environment"
+            preDexLibraries = true
+        }
     }
 }
 

--- a/app/scripts/travis_before_script.sh
+++ b/app/scripts/travis_before_script.sh
@@ -3,9 +3,15 @@
 set -e
 
 if [ "$BUILD_GROUP" == "instrument" ]; then
-    android-update-sdk --components=sys-img-armeabi-v7a-android-19 --accept-licenses='android-sdk-license-[0-9a-f]{8}'
-    echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a --skin QVGA
-    emulator -avd test -no-audio -no-skin -netfast -no-window &
+
+    mkdir -p ${ANDROID_HOME}licenses
+    echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > ${ANDROID_HOME}licenses/android-sdk-license
+
+    ${ANDROID_HOME}tools/bin/sdkmanager --channel=0 "system-images;android-19;default;armeabi-v7a" "emulator"
+
+    echo no | ${ANDROID_HOME}tools/bin/avdmanager create avd --force -n test --abi "armeabi-v7a" -k "system-images;android-19;default;armeabi-v7a" --device "3.2in QVGA (ADP2)"
+    ${ANDROID_HOME}emulator/emulator -avd test -no-audio -netfast -no-window &
+
 else
     echo "$BUILD_GROUP is unknown"
 fi

--- a/app/scripts/travis_script.sh
+++ b/app/scripts/travis_script.sh
@@ -6,7 +6,7 @@ elif [ "$BUILD_GROUP" == "instrument" ]; then
 
     export ADB_INSTALL_TIMEOUT=30
 
-    ./gradlew :app:assembleDebug :app:assembleDebugAndroidTest
+    ./gradlew :app:assembleDebugAndroidTest
 
     which android-wait-for-emulator > /dev/null
 


### PR DESCRIPTION
Use trusty distribution because it's new and going to be the standard for a while